### PR TITLE
Lower PHP version requirement to 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ and then by [made into composer package](https://github.com/zachflower/php-indef
 
 ### Via Composer
 
-Require the library and update via [Composer](https://getcomposer.org/):
+Add the library to your `Composer.json` file
 
 ```
-composer require spenserhale/indefinite-article
-composer update
+"repositories": [
+  {
+    "type": "vcs",
+    "url": "https://github.com/bmstanley/php-indefinite-article"
+  }
+],
+"require": {
+  "bmstanley/indefinite-article": "^1.0"
+},
 ```
 
-### Manually
-
-Download the [latest release](https://github.com/bmstanley/php-indefinite-article/archive/master.zip), extract into a directory called `indefinite-article`, and include the library at the beginning of your script:
-
-```
-include_once('./indefinite-articles/src/IndefiniteArticle.php');
-use \IndefiniteArticle\IndefiniteArticle;
-```
+Run `composer install` to download and install the repository
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 PHP implementation of the [Lingua::EN::Inflect](http://search.cpan.org/dist/Lingua-EN-Inflect/lib/Lingua/EN/Inflect.pm) 
 Perl module's A() and AN() subroutines, 
 originally [ported to PHP](https://github.com/Kaivosukeltaja/php-indefinite-article) by [Niko Salminen](http://nikosalminen.com),
-and then by [make into composer package](https://github.com/zachflower/php-indefinite-article) by [Zach Flower](https://zacharyflower.com/).
+and then by [made into composer package](https://github.com/zachflower/php-indefinite-article) by [Zach Flower](https://zacharyflower.com/).
 
 ## Installation
 
@@ -18,7 +18,7 @@ composer update
 
 ### Manually
 
-Download the [latest release](https://github.com/spenserhale/php-indefinite-article/archive/master.zip), extract into a directory called `indefinite-article`, and include the library at the beginning of your script:
+Download the [latest release](https://github.com/bmstanley/php-indefinite-article/archive/master.zip), extract into a directory called `indefinite-article`, and include the library at the beginning of your script:
 
 ```
 include_once('./indefinite-articles/src/IndefiniteArticle.php');
@@ -27,10 +27,10 @@ use \IndefiniteArticle\IndefiniteArticle;
 
 ## Usage
 
-The PHP Indefinite Article Library is used to determine the proper indefinite article to use before a word ('a' or 'an'). To do so, simply call the `A()` method with your word or phrase:
+The PHP Indefinite Article Library is used to determine the proper indefinite article to use before a word ('a' or 'an'). To do so, simply call the `invoke()` method with your word or phrase:
 
 ```
-IndefiniteArticle::A('elephant')
+IndefiniteArticle::invoke('elephant')
 ```
 
 The method will return a string prefixed with the appropriate indefinite article:
@@ -41,4 +41,4 @@ an elephant
 
 ## Copyright and License
 
-Original Perl module Copyright &copy; 1997-2009 Damian Conway; Original PHP port Copyright &copy; 2012 Niko Salminen; Original library copyright &copy; 2016 Zachary Flower; Current library copyright &copy; 2018 Spenser Hale; Code released under the [BSD license](LICENSE).
+Original Perl module Copyright &copy; 1997-2009 Damian Conway; Original PHP port Copyright &copy; 2012 Niko Salminen; Original library copyright &copy; 2016 Zachary Flower; Current library copyright &copy; 2018 Spenser Hale; 2019 Brian Stanley; Code released under the [BSD license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ an elephant
 
 ## Copyright and License
 
-Original Perl module Copyright &copy; 1997-2009 Damian Conway; Original PHP port Copyright &copy; 2012 Niko Salminen; Original library copyright &copy; 2016 Zachary Flower; Current library copyright &copy; 2018 Spenser Hale; 2019 Brian Stanley; Code released under the [BSD license](LICENSE).
+Original Perl module Copyright &copy; 1997-2009 Damian Conway; Original PHP port Copyright &copy; 2012 Niko Salminen; Original library copyright &copy; 2016 Zachary Flower and copyright &copy; 2018 Spenser Hale; Current library copyright &copy; 2019 Brian Stanley; Code released under the [BSD license](LICENSE).

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "spenserhale/indefinite-article",
+  "name": "bmstanley/indefinite-article",
   "description":"Grammatical utility class for prepending the appropriate indefinite article to a word (a/an)",
   "keywords":[
     "php",
@@ -9,8 +9,8 @@
   "license": "BSD-2-Clause",
   "authors": [
     {
-      "name": "Spenser Hale",
-      "email": "spenserhaledeveloper@outlook.com"
+      "name": "Brian Stanley",
+      "email": "bmstanley87@gmail.com"
     }
   ],
   "autoload": {
@@ -19,10 +19,10 @@
     }
   },
   "require": {
-    "php": ">= 7.2.2"
+    "php": ">= 7.0"
   },
   "require-dev": {
     "nilportugues/php_backslasher": "^1.1",
-    "phpunit/phpunit": "^7.2"
+    "phpunit/phpunit": "~6.0"
   }
 }

--- a/src/IndefiniteArticle.php
+++ b/src/IndefiniteArticle.php
@@ -54,7 +54,7 @@ class IndefiniteArticle
 
         \preg_match("/\A(\s*)(?:an?\s+)?(.+?)(\s*)\Z/i", $input, $matches);
 
-        [, $pre, $word, $post] = $matches;
+        list(, $pre, $word, $post) = $matches;
 
         if (\null === $word) {
             return $input;
@@ -83,7 +83,7 @@ class IndefiniteArticle
         }
 
         foreach (self::$rules as $rule) {
-            [$pattern, $article] = $rule;
+            list($pattern, $article) = $rule;
             if (\preg_match($pattern, $word)) {
                 return $article . ' ' . $word;
             }

--- a/src/IndefiniteArticle.php
+++ b/src/IndefiniteArticle.php
@@ -4,9 +4,9 @@ namespace IndefiniteArticle;
 
 class IndefiniteArticle
 {
-    private const A = 'a';
+    const A = 'a';
 
-    private const AN = 'an';
+    const AN = 'an';
 
     private static $rules = [
         // any number starting with an '8' uses 'an'


### PR DESCRIPTION
- Removed the use of [class constant visibility](https://www.php.net/manual/en/language.oop5.constants.php)
- Removed the `list` short-hand syntax (PHP 7.1+) and replaced it with the full [language construct name](https://www.php.net/manual/en/function.list.php)
- Updated version requirement in the `README`